### PR TITLE
feat: remove html-extra dep

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -15,7 +15,6 @@
         "elm/core": "1.0.5 <= v < 2.0.0",
         "elm/json": "1.1.3 <= v < 2.0.0",
         "elm-community/list-extra": "8.3.0 <= v < 9.0.0",
-        "matken11235/html-styled-extra": "1.0.1 <= v < 2.0.0",
         "rtfeldman/elm-css": "16.1.0 <= v < 17.0.0"
     },
     "test-dependencies": {

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "Confidenceman02/elm-select",
     "summary": "A Handsome configurable select inspired by Culture Amp's Kaizen select.",
     "license": "BSD-3-Clause",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "exposed-modules": [
         "Select",
         "Select.Styles"

--- a/examples-optimized/elm.json
+++ b/examples-optimized/elm.json
@@ -14,7 +14,6 @@
             "elm/json": "1.1.3",
             "elm/time": "1.0.0",
             "elm-community/list-extra": "8.3.0",
-            "matken11235/html-styled-extra": "1.0.1",
             "rtfeldman/elm-css": "16.1.0"
         },
         "indirect": {

--- a/examples/elm.json
+++ b/examples/elm.json
@@ -14,7 +14,6 @@
             "elm/json": "1.1.3",
             "elm/time": "1.0.0",
             "elm-community/list-extra": "8.3.0",
-            "matken11235/html-styled-extra": "1.0.1",
             "rtfeldman/elm-css": "16.1.0"
         },
         "indirect": {

--- a/src/Select.elm
+++ b/src/Select.elm
@@ -47,7 +47,6 @@ import Html.Styled exposing (Html, button, div, input, li, option, select, span,
 import Html.Styled.Attributes as StyledAttribs exposing (attribute, id, readonly, style, tabindex, value)
 import Html.Styled.Attributes.Aria as Aria exposing (ariaSelected, role)
 import Html.Styled.Events exposing (custom, on, onBlur, onFocus, preventDefaultOn)
-import Html.Styled.Extra exposing (viewIf)
 import Html.Styled.Keyed as Keyed
 import Html.Styled.Lazy exposing (lazy)
 import Json.Decode as Decode
@@ -1377,7 +1376,7 @@ view (Config config) selectId =
                         [ StyledAttribs.css
                             [ Css.alignItems Css.center, Css.alignSelf Css.stretch, Css.displayFlex, Css.flexShrink Css.zero, Css.boxSizing Css.borderBox ]
                         ]
-                        [ viewIf clearButtonVisible <| div [ StyledAttribs.css indicatorContainerStyles ] [ clearIndicator config selectId ]
+                        [ Internal.viewIf clearButtonVisible <| div [ StyledAttribs.css indicatorContainerStyles ] [ clearIndicator config selectId ]
                         , div [ StyledAttribs.css indicatorContainerStyles ]
                             [ span
                                 [ StyledAttribs.css
@@ -1394,7 +1393,7 @@ view (Config config) selectId =
                             [ dropdownIndicator config.styles config.disabled
                             ]
                         ]
-                    , viewIf state_.menuOpen
+                    , Internal.viewIf state_.menuOpen
                         (lazy viewMenu
                             (ViewMenuData
                                 config.variant

--- a/src/Select/Internal.elm
+++ b/src/Select/Internal.elm
@@ -1,4 +1,6 @@
-module Select.Internal exposing (Direction(..), calculateNextActiveTarget, shouldQueryNextTargetElement)
+module Select.Internal exposing (Direction(..), calculateNextActiveTarget, shouldQueryNextTargetElement, viewIf)
+
+import Html.Styled as Styled
 
 
 type Direction
@@ -35,3 +37,17 @@ calculateNextActiveTarget currentTargetIndex totalTargetCount direction =
 shouldQueryNextTargetElement : Int -> Int -> Bool
 shouldQueryNextTargetElement nextTargetIndex activeTargetIndex =
     nextTargetIndex /= activeTargetIndex
+
+
+nothing : Styled.Html msg
+nothing =
+    Styled.text ""
+
+
+viewIf : Bool -> Styled.Html msg -> Styled.Html msg
+viewIf condition html =
+    if condition then
+        html
+
+    else
+        nothing


### PR DESCRIPTION
Fixes #26 

Seems like the html-extra lib that was being used has disappeared.
Because only the `viewIf` function was being used it probably makes sense
just duplicating the code instead of needing the dependency.

