### PR TITLE
fix: clear-button-submits-form

### DIFF
--- a/examples/Form.elm
+++ b/examples/Form.elm
@@ -1,0 +1,98 @@
+module Form exposing (..)
+
+import Browser
+import Css
+import Html.Styled as Styled exposing (Html, div, form)
+import Html.Styled.Attributes as StyledAttribs
+import Select exposing (MenuItem, initState, selectIdentifier, update)
+
+
+type Msg
+    = SelectMsg (Select.Msg String)
+
+
+type alias Model =
+    { selectState : Select.State
+    , items : List (MenuItem String)
+    , selectedItem : Maybe String
+    }
+
+
+init : ( Model, Cmd Msg )
+init =
+    ( { selectState = initState
+      , items =
+            [ { item = "Elm", label = "Elm" }
+            , { item = "Is", label = "Is" }
+            , { item = "Really", label = "Really" }
+            , { item = "Great", label = "Great" }
+            ]
+      , selectedItem = Nothing
+      }
+    , Cmd.none
+    )
+
+
+main : Program () Model Msg
+main =
+    Browser.element
+        { init = always init
+        , view = view >> Styled.toUnstyled
+        , update = update
+        , subscriptions = \_ -> Sub.none
+        }
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        SelectMsg sm ->
+            let
+                ( maybeAction, selectState, cmds ) =
+                    Select.update sm model.selectState
+
+                updatedSelectedItem =
+                    case maybeAction of
+                        Just (Select.Select i) ->
+                            Just i |> Debug.log "Selected"
+
+                        Just Select.ClearSingleSelectItem ->
+                            Nothing
+
+                        _ ->
+                            model.selectedItem
+            in
+            ( { model | selectState = selectState, selectedItem = updatedSelectedItem }, Cmd.map SelectMsg cmds )
+
+
+view : Model -> Html Msg
+view m =
+    let
+        selectedItem =
+            case m.selectedItem of
+                Just i ->
+                    Just { item = i, label = i }
+
+                _ ->
+                    Nothing
+    in
+    form [ StyledAttribs.method "POST", StyledAttribs.action "/something" ]
+        [ div
+            [ StyledAttribs.css
+                [ Css.marginTop (Css.px 20)
+                , Css.width (Css.pct 50)
+                , Css.marginLeft Css.auto
+                , Css.marginRight Css.auto
+                ]
+            ]
+            [ Styled.map SelectMsg <|
+                Select.view
+                    (Select.single selectedItem
+                        |> Select.state m.selectState
+                        |> Select.menuItems m.items
+                        |> Select.placeholder "Placeholder"
+                        |> Select.clearable True
+                    )
+                    (selectIdentifier "SingleSelectExample")
+            ]
+        ]

--- a/src/Select.elm
+++ b/src/Select.elm
@@ -44,7 +44,7 @@ module Select exposing
 import Browser.Dom as Dom
 import Css
 import Html.Styled exposing (Html, button, div, input, li, option, select, span, text)
-import Html.Styled.Attributes as StyledAttribs exposing (attribute, id, readonly, style, tabindex, value)
+import Html.Styled.Attributes as StyledAttribs exposing (attribute, id, readonly, style, tabindex, type_, value)
 import Html.Styled.Attributes.Aria as Aria exposing (ariaSelected, role)
 import Html.Styled.Events exposing (custom, on, onBlur, onFocus, preventDefaultOn)
 import Html.Styled.Keyed as Keyed
@@ -2332,7 +2332,9 @@ clearIndicator config id =
             Styles.getControlConfig config.styles
     in
     button
-        [ custom "mousedown" <|
+        [ attribute "data-test-id" "clear"
+        , type_ "button"
+        , custom "mousedown" <|
             Decode.map (\msg -> { message = msg, stopPropagation = True, preventDefault = True }) <|
                 Decode.succeed SingleSelectClearButtonMouseDowned
         , StyledAttribs.css (resolveIconButtonStyles ++ iconButtonStyles)

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -34,6 +34,7 @@ describe("examples", () => {
     );
     const longMenuVisible = await page.isVisible("text=LongMenu.elm");
     const singleMenuVisible = await page.isVisible("text=Single.elm");
+    const formVisible = await page.isVisible("text=Form.elm");
 
     expect(singleExampleVisible).toBeTruthy();
     expect(nativeSingle).toBeTruthy();
@@ -44,6 +45,27 @@ describe("examples", () => {
     expect(clearableExampleVisible).toBeTruthy();
     expect(longMenuVisible).toBeTruthy();
     expect(singleMenuVisible).toBeTruthy();
+    expect(formVisible).toBeTruthy();
+  });
+});
+
+describe("Form", () => {
+  it("it doesn't submit the form when clearing a selected item with Enter", async () => {
+    const page = await browser.newPage();
+    let hasSubmitted = false;
+    await page.goto(`${BASE_URI}/Form.elm`);
+    page.on("framenavigated", () => {
+      hasSubmitted = true;
+    });
+    await page.click("[data-test-id=selectContainer]");
+    await page.waitForSelector("[data-test-id=listBox]");
+    await page.keyboard.press("Enter");
+    await page.waitForSelector("[data-test-id=clear]");
+    await page.focus("[data-test-id=clear]");
+    await page.keyboard.press("Enter");
+    await page.waitForTimeout(100);
+
+    expect(hasSubmitted).toBeFalsy();
   });
 });
 


### PR DESCRIPTION
fixes #55 

# Context
When the `clearable` flag for a select is `True` a clear indicator button renders which will clear a selected item.
When the select is inside of a form, interacting with the clear button with the `enter` key will inadvertently submit the form. This is due to buttons defaulting to `type 'submit'` by default. 

## Work completed
- Set a type on the button to "button"
- Add regression test.
- Add example with select in form