### PR TITLE
Custom views

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,12 @@ init : Model
 init = 
     {  selectState = Select.initState
     ,  items = 
-           [ { item = Australia, label = "Australia" }
-           , { item = Japan, label = "Japan" }
-           , { item = Taiwan, label = "Taiwan" }
+           [ basicMenuItem 
+                { item = Australia, label = "Australia" }
+           , basicMenuItem
+                { item = Japan, label = "Japan" }
+           , basicMenuItem
+                { item = Taiwan, label = "Taiwan" }
            ]
     ,  selectedCountry = Nothing
     }
@@ -132,9 +135,15 @@ The select [view](/packages/Confidenceman02/elm-select/latest/Select#view) funct
 selectedCountryToMenuItem : Country -> Select.MenuItem Country
 selectedCountryToMenuItem country =
     case country of 
-        Australia -> { item = Australia, label = "Australia" }
-        Japan -> { item = Japan, label = "Japan" }
-        Taiwan -> { item = Taiwan, label = "Taiwan" }
+        Australia -> 
+            basicMenuitem { item = Australia, label = "Australia" }
+
+        Japan -> 
+            basicMenuitem { item = Japan, label = "Japan" }
+
+        Taiwan -> 
+            basicMenuitem { item = Taiwan, label = "Taiwan" }
+
         -- other countries
         
         
@@ -222,9 +231,12 @@ init : Model
 init = 
     {  selectState = Select.initState |> Select.jsOptimize True
     ,  items = 
-           [ { item = Australia, label = "Australia" }
-           , { item = Japan, label = "Japan" }
-           , { item = Taiwan, label = "Taiwan" }
+           [ basicMenuitem 
+                { item = Australia, label = "Australia" }
+           , basicMenuItem
+                { item = Japan, label = "Japan" }
+           , basicMenuitem
+                { item = Taiwan, label = "Taiwan" }
            ]
     ,  selectedCountry = Nothing
     }

--- a/elm-tooling.json
+++ b/elm-tooling.json
@@ -1,7 +1,6 @@
 {
-  "entrypoints": ["./src/Main.elm", "./examples/Single.elm"],
-  "tools": {
-    "elm": "0.19.1",
-    "elm-format": "0.8.5"
-  }
+    "tools": {
+        "elm": "0.19.1",
+        "elm-format": "0.8.5"
+    }
 }

--- a/examples-optimized/Main.elm
+++ b/examples-optimized/Main.elm
@@ -22,10 +22,10 @@ init : ( Model, Cmd Msg )
 init =
     ( { selectState = initState |> jsOptimize True
       , items =
-            [ { item = "Elm", label = "Elm" }
-            , { item = "Is", label = "Is" }
-            , { item = "Really", label = "Really" }
-            , { item = "Great", label = "Great" }
+            [ Select.basicMenuItem { item = "Elm", label = "Elm" }
+            , Select.basicMenuItem { item = "Is", label = "Is" }
+            , Select.basicMenuItem { item = "Really", label = "Really" }
+            , Select.basicMenuItem { item = "Great", label = "Great" }
             ]
       , selectedItem = Nothing
       }
@@ -68,7 +68,7 @@ view m =
         selectedItem =
             case m.selectedItem of
                 Just i ->
-                    Just { item = i, label = i }
+                    Just (Select.basicMenuItem { item = i, label = i })
 
                 _ ->
                     Nothing

--- a/examples/Disabled.elm
+++ b/examples/Disabled.elm
@@ -22,10 +22,10 @@ init : ( Model, Cmd Msg )
 init =
     ( { selectState = initState
       , items =
-            [ { item = "Elm", label = "Elm" }
-            , { item = "Is", label = "Is" }
-            , { item = "Really", label = "Really" }
-            , { item = "Great", label = "Great" }
+            [ Select.basicMenuItem { item = "Elm", label = "Elm" }
+            , Select.basicMenuItem { item = "Is", label = "Is" }
+            , Select.basicMenuItem { item = "Really", label = "Really" }
+            , Select.basicMenuItem { item = "Great", label = "Great" }
             ]
       , selectedItem = Nothing
       }
@@ -68,7 +68,7 @@ view m =
         selectedItem =
             case m.selectedItem of
                 Just i ->
-                    Just { item = i, label = i }
+                    Just (Select.basicMenuItem { item = i, label = i })
 
                 _ ->
                     Nothing

--- a/examples/Form.elm
+++ b/examples/Form.elm
@@ -22,10 +22,10 @@ init : ( Model, Cmd Msg )
 init =
     ( { selectState = initState
       , items =
-            [ { item = "Elm", label = "Elm" }
-            , { item = "Is", label = "Is" }
-            , { item = "Really", label = "Really" }
-            , { item = "Great", label = "Great" }
+            [ Select.basicMenuItem { item = "Elm", label = "Elm" }
+            , Select.basicMenuItem { item = "Is", label = "Is" }
+            , Select.basicMenuItem { item = "Really", label = "Really" }
+            , Select.basicMenuItem { item = "Great", label = "Great" }
             ]
       , selectedItem = Nothing
       }
@@ -71,7 +71,7 @@ view m =
         selectedItem =
             case m.selectedItem of
                 Just i ->
-                    Just { item = i, label = i }
+                    Just (Select.basicMenuItem { item = i, label = i })
 
                 _ ->
                     Nothing

--- a/examples/LongMenu.elm
+++ b/examples/LongMenu.elm
@@ -22,17 +22,17 @@ init : ( Model, Cmd Msg )
 init =
     ( { selectState = initState
       , items =
-            [ { item = "Elm", label = "Elm" }
-            , { item = "Is", label = "Is" }
-            , { item = "Really", label = "Really" }
-            , { item = "Great", label = "Great" }
-            , { item = "And", label = "And" }
-            , { item = "Fun", label = "Fun" }
-            , { item = "To", label = "To" }
-            , { item = "Use", label = "Use" }
-            , { item = "All", label = "All" }
-            , { item = "The", label = "The" }
-            , { item = "Time", label = "Time" }
+            [ Select.basicMenuItem { item = "Elm", label = "Elm" }
+            , Select.basicMenuItem { item = "Is", label = "Is" }
+            , Select.basicMenuItem { item = "Really", label = "Really" }
+            , Select.basicMenuItem { item = "Great", label = "Great" }
+            , Select.basicMenuItem { item = "And", label = "And" }
+            , Select.basicMenuItem { item = "Fun", label = "Fun" }
+            , Select.basicMenuItem { item = "To", label = "To" }
+            , Select.basicMenuItem { item = "Use", label = "Use" }
+            , Select.basicMenuItem { item = "All", label = "All" }
+            , Select.basicMenuItem { item = "The", label = "The" }
+            , Select.basicMenuItem { item = "Time", label = "Time" }
             ]
       , selectedItem = Nothing
       }
@@ -75,7 +75,7 @@ view m =
         selectedItem =
             case m.selectedItem of
                 Just i ->
-                    Just { item = i, label = i }
+                    Just (Select.basicMenuItem { item = i, label = i })
 
                 _ ->
                     Nothing

--- a/examples/Multi.elm
+++ b/examples/Multi.elm
@@ -22,10 +22,10 @@ init : ( Model, Cmd Msg )
 init =
     ( { selectState = initState
       , items =
-            [ { item = "Elm", label = "Elm" }
-            , { item = "Is", label = "Is" }
-            , { item = "Really", label = "Really" }
-            , { item = "Great", label = "Great" }
+            [ Select.basicMenuItem { item = "Elm", label = "Elm" }
+            , Select.basicMenuItem { item = "Is", label = "Is" }
+            , Select.basicMenuItem { item = "Really", label = "Really" }
+            , Select.basicMenuItem { item = "Great", label = "Great" }
             ]
       , selectedItems = []
       }
@@ -69,7 +69,7 @@ view : Model -> Html Msg
 view m =
     let
         selectedItems =
-            List.map (\i -> { item = i, label = i }) m.selectedItems
+            List.map (\i -> Select.basicMenuItem { item = i, label = i }) m.selectedItems
     in
     div
         [ StyledAttribs.css

--- a/examples/MultiAsync.elm
+++ b/examples/MultiAsync.elm
@@ -22,10 +22,10 @@ init : ( Model, Cmd Msg )
 init =
     ( { selectState = initState
       , items =
-            [ { item = "Elm", label = "Elm" }
-            , { item = "Is", label = "Is" }
-            , { item = "Really", label = "Really" }
-            , { item = "Great", label = "Great" }
+            [ Select.basicMenuItem { item = "Elm", label = "Elm" }
+            , Select.basicMenuItem { item = "Is", label = "Is" }
+            , Select.basicMenuItem { item = "Really", label = "Really" }
+            , Select.basicMenuItem { item = "Great", label = "Great" }
             ]
       , selectedItems = []
       }
@@ -69,7 +69,7 @@ view : Model -> Html Msg
 view m =
     let
         selectedItems =
-            List.map (\i -> { item = i, label = i }) m.selectedItems
+            List.map (\i -> Select.basicMenuItem { item = i, label = i }) m.selectedItems
     in
     div
         [ StyledAttribs.css

--- a/examples/MultiTruncation.elm
+++ b/examples/MultiTruncation.elm
@@ -22,10 +22,10 @@ init : ( Model, Cmd Msg )
 init =
     ( { selectState = initState
       , items =
-            [ { item = "Elmmmmmmm", label = "Elmmmmmmm" }
-            , { item = "Isssssss", label = "Isssssss" }
-            , { item = "Reallyyyyyyy", label = "Reallyyyyyyy" }
-            , { item = "Greattttttt", label = "Greattttttt" }
+            [ Select.basicMenuItem { item = "Elmmmmmmm", label = "Elmmmmmmm" }
+            , Select.basicMenuItem { item = "Isssssss", label = "Isssssss" }
+            , Select.basicMenuItem { item = "Reallyyyyyyy", label = "Reallyyyyyyy" }
+            , Select.basicMenuItem { item = "Greattttttt", label = "Greattttttt" }
             ]
       , selectedItems = []
       }
@@ -69,7 +69,7 @@ view : Model -> Html Msg
 view m =
     let
         selectedItems =
-            List.map (\i -> { item = i, label = i }) m.selectedItems
+            List.map (\i -> Select.basicMenuItem { item = i, label = i }) m.selectedItems
     in
     div
         [ StyledAttribs.css

--- a/examples/NativeSingle.elm
+++ b/examples/NativeSingle.elm
@@ -22,10 +22,10 @@ init : ( Model, Cmd Msg )
 init =
     ( { selectState = initState
       , items =
-            [ { item = "Elm", label = "Elm" }
-            , { item = "Is", label = "Is" }
-            , { item = "Really", label = "Really" }
-            , { item = "Great", label = "Great" }
+            [ Select.basicMenuItem { item = "Elm", label = "Elm" }
+            , Select.basicMenuItem { item = "Is", label = "Is" }
+            , Select.basicMenuItem { item = "Really", label = "Really" }
+            , Select.basicMenuItem { item = "Great", label = "Great" }
             ]
       , selectedItem = Nothing
       }
@@ -66,12 +66,12 @@ view : Model -> Html Msg
 view m =
     let
         selectedItem =
-          case m.selectedItem of 
-            Just it ->
-              Just { item = it, label = it }
-            _ ->
-              Nothing
+            case m.selectedItem of
+                Just it ->
+                    Just (Select.basicMenuItem { item = it, label = it })
 
+                _ ->
+                    Nothing
     in
     div
         [ StyledAttribs.css
@@ -80,7 +80,7 @@ view m =
         ]
         [ Styled.map SelectMsg <|
             Select.view
-                (Select.singleNative (selectedItem)
+                (Select.singleNative selectedItem
                     |> Select.state m.selectState
                     |> Select.menuItems m.items
                     |> Select.placeholder "Select something"

--- a/examples/Single.elm
+++ b/examples/Single.elm
@@ -22,10 +22,10 @@ init : ( Model, Cmd Msg )
 init =
     ( { selectState = initState
       , items =
-            [ { item = "Elm", label = "Elm" }
-            , { item = "Is", label = "Is" }
-            , { item = "Really", label = "Really" }
-            , { item = "Great", label = "Great" }
+            [ Select.basicMenuItem { item = "Elm", label = "Elm" }
+            , Select.basicMenuItem { item = "Is", label = "Is" }
+            , Select.basicMenuItem { item = "Really", label = "Really" }
+            , Select.basicMenuItem { item = "Great", label = "Great" }
             ]
       , selectedItem = Nothing
       }
@@ -68,7 +68,7 @@ view m =
         selectedItem =
             case m.selectedItem of
                 Just i ->
-                    Just { item = i, label = i }
+                    Just (Select.basicMenuItem { item = i, label = i })
 
                 _ ->
                     Nothing

--- a/examples/SingleClearable.elm
+++ b/examples/SingleClearable.elm
@@ -22,10 +22,10 @@ init : ( Model, Cmd Msg )
 init =
     ( { selectState = initState
       , items =
-            [ { item = "Elm", label = "Elm" }
-            , { item = "Is", label = "Is" }
-            , { item = "Really", label = "Really" }
-            , { item = "Great", label = "Great" }
+            [ Select.basicMenuItem { item = "Elm", label = "Elm" }
+            , Select.basicMenuItem { item = "Is", label = "Is" }
+            , Select.basicMenuItem { item = "Really", label = "Really" }
+            , Select.basicMenuItem { item = "Great", label = "Great" }
             ]
       , selectedItem = Nothing
       }
@@ -71,7 +71,7 @@ view m =
         selectedItem =
             case m.selectedItem of
                 Just i ->
-                    Just { item = i, label = i }
+                    Just (Select.basicMenuItem { item = i, label = i })
 
                 _ ->
                     Nothing

--- a/examples/SingleSearchable.elm
+++ b/examples/SingleSearchable.elm
@@ -22,10 +22,10 @@ init : ( Model, Cmd Msg )
 init =
     ( { selectState = initState
       , items =
-            [ { item = "Elm", label = "Elm" }
-            , { item = "Is", label = "Is" }
-            , { item = "Really", label = "Really" }
-            , { item = "Great", label = "Great" }
+            [ Select.basicMenuItem { item = "Elm", label = "Elm" }
+            , Select.basicMenuItem { item = "Is", label = "Is" }
+            , Select.basicMenuItem { item = "Really", label = "Really" }
+            , Select.basicMenuItem { item = "Great", label = "Great" }
             ]
       , selectedItem = Nothing
       }
@@ -68,7 +68,7 @@ view m =
         selectedItem =
             case m.selectedItem of
                 Just i ->
-                    Just { item = i, label = i }
+                    Just (Select.basicMenuItem { item = i, label = i })
 
                 _ ->
                     Nothing

--- a/examples/Styled.elm
+++ b/examples/Styled.elm
@@ -65,7 +65,7 @@ update msg model =
                             ( { model
                                 | selectState = selectState
                                 , selectedItem = Just i
-                                , selectedItems = model.selectedItems ++ [ { label = i, item = i } ]
+                                , selectedItems = model.selectedItems ++ [ Select.basicMenuItem { label = i, item = i } ]
                               }
                             , Cmd.none
                             )
@@ -85,10 +85,10 @@ update msg model =
             ( { model
                 | items =
                     Loaded
-                        [ { item = "Elm", label = "Elm" }
-                        , { item = "Really", label = "Really" }
-                        , { item = "Inspires", label = "Inspires" }
-                        , { item = "Learning", label = "Learning" }
+                        [ Select.basicMenuItem { item = "Elm", label = "Elm" }
+                        , Select.basicMenuItem { item = "Really", label = "Really" }
+                        , Select.basicMenuItem { item = "Inspires", label = "Inspires" }
+                        , Select.basicMenuItem { item = "Learning", label = "Learning" }
                         ]
               }
             , Cmd.none
@@ -101,7 +101,7 @@ view m =
         selectedItem =
             case m.selectedItem of
                 Just i ->
-                    Just { item = i, label = i }
+                    Just (Select.basicMenuItem { item = i, label = i })
 
                 _ ->
                     Nothing
@@ -159,8 +159,8 @@ view m =
 
 allItems : List (Select.MenuItem String)
 allItems =
-    [ { item = "Elm", label = "Elm" }
-    , { item = "Really", label = "Really" }
-    , { item = "Inspires", label = "Inspires" }
-    , { item = "Learning", label = "Learning" }
+    [ Select.basicMenuItem { item = "Elm", label = "Elm" }
+    , Select.basicMenuItem { item = "Really", label = "Really" }
+    , Select.basicMenuItem { item = "Inspires", label = "Inspires" }
+    , Select.basicMenuItem { item = "Learning", label = "Learning" }
     ]

--- a/src/Select.elm
+++ b/src/Select.elm
@@ -1,5 +1,5 @@
 module Select exposing
-    ( State, MenuItem, Action(..), initState, Msg, menuItems, placeholder, selectIdentifier, state, update, view, searchable, setStyles
+    ( State, MenuItem, BasicMenuItem, basicMenuItem, Action(..), initState, Msg, menuItems, placeholder, selectIdentifier, state, update, view, searchable, setStyles
     , single, clearable
     , multi, truncateMultiTag, multiTagColor, initMultiConfig
     , singleNative
@@ -12,7 +12,7 @@ module Select exposing
 
 # Set up
 
-@docs State, MenuItem, Action, initState, Msg, menuItems, placeholder, selectIdentifier, state, update, view, searchable, setStyles
+@docs State, MenuItem, BasicMenuItem, basicMenuItem, Action, initState, Msg, menuItems, placeholder, selectIdentifier, state, update, view, searchable, setStyles
 
 
 # Single select
@@ -190,13 +190,13 @@ type MenuListElement
 -- These data structures make using 'lazy' function a breeze
 
 
-type alias ViewMenuItemData item =
+type alias ViewBasicMenuItemData item =
     { index : Int
     , itemSelected : Bool
     , isClickFocused : Bool
     , menuItemIsTarget : Bool
     , selectId : SelectId
-    , menuItem : MenuItem item
+    , menuItem : BasicMenuItem item
     , menuNavigation : MenuNavigation
     , initialMousedown : InitialMousedown
     , variant : Variant item
@@ -298,7 +298,12 @@ type MenuNavigation
     | Mouse
 
 
-{-| The menu item that will be represented in the menu list.
+{-| -}
+type MenuItem item
+    = Basic (BasicMenuItem item)
+
+
+{-| A menu item that will be represented in the menu list.
 
 The `item` property is the type representation of the menu item that will be used in an Action.
 
@@ -311,9 +316,9 @@ The `label` is the text representation that will be shown in the menu.
 
     toolItems : MenuItem Tool
     toolItems =
-        [ { item = Screwdriver, label = "Screwdriver" }
-        , { item = Hammer, label = "Hammer" }
-        , { item = Drill, label = "Drill" }
+        [ basicMenuItem { item = Screwdriver, label = "Screwdriver" }
+        , basicMenuItem { item = Hammer, label = "Hammer" }
+        , basicMenuItem { item = Drill, label = "Drill" }
         ]
 
     yourView model =
@@ -325,8 +330,10 @@ The `label` is the text representation that will be shown in the menu.
                 )
                 (selectIdentifier "SingleSelectExample")
 
+Combine this with [basicMenuItem](#basicMenuItem) to create a [MenuItem](#MenuItem)
+
 -}
-type alias MenuItem item =
+type alias BasicMenuItem item =
     { item : item
     , label : String
     }
@@ -344,18 +351,21 @@ type alias MenuItem item =
         | Taiwan
 
     type alias Model =
-        { selectState : Select.State
-        , items : List (Select.MenuItem Country)
+        { selectState : State
+        , items : List (MenuItem Country)
         , selectedCountry : Maybe Country
         }
 
     init : Model
     init =
-        { selectState = Select.initState
+        { selectState = initState
         , items =
-            [ { item = Australia, label = "Australia" }
-            , { item = Japan, label = "Japan" }
-            , { item = Taiwan, label = "Taiwan" }
+            [ basicMenuItem
+                { item = Australia, label = "Australia" }
+            , basicMenuItem
+                { item = Japan, label = "Japan" }
+            , basicMenuItem
+                { item = Taiwan, label = "Taiwan" }
             ]
         , selectedCountry = Nothing
         }
@@ -462,6 +472,33 @@ multiTagColor c (MultiSelectConfig config) =
 
 
 
+-- MENU ITEM MODIFIERS
+
+
+{-| Create a [basic](#BasicMenuItem) type of [MenuItem](#MenuItem).
+
+        type Tool
+            = Screwdriver
+            | Hammer
+            | Drill
+
+        menuItems : List (MenuItem Tool)
+        menuItems =
+            [ basicMenuItem
+                { item = Screwdriver, label = "Screwdriver" }
+            , basicMenuItem
+                { item = Hammer, label = "Hammer" }
+            , basicMenuItem
+                { item = Drill, label = "Drill" }
+            ]
+
+-}
+basicMenuItem : BasicMenuItem item -> MenuItem item
+basicMenuItem defItem =
+    Basic defItem
+
+
+
 -- MODIFIERS
 
 
@@ -555,7 +592,9 @@ NOTE: When using the (multi) select, selected items will be reflected as a tags 
 visually removed from the menu list.
 
       items =
-          [ { item = SomeValue, label = "Some label" } ]
+          [ basicMenuItem
+              { item = SomeValue, label = "Some label" }
+          ]
 
       yourView =
           view
@@ -572,12 +611,17 @@ menuItems items (Config config) =
 
 To handle a cleared item refer to the [ClearedSingleSelect](#Action ) action.
 
+      items =
+          [ basicMenuItem
+              { item = SomeValue, label = "Some label" }
+          ]
+
         yourView model =
             Html.map SelectMsg <|
                 view
                     ( single Nothing
                         |> clearable True
-                        |> menuItems -- [ menu items ]
+                        |> menuItems items
                     )
                     (selectIdentifier "SingleSelectExample")
 
@@ -738,9 +782,11 @@ type NativeVariant item
 
       countries : List (MenuItem Country)
       countries =
-          [ { item = Australia, label = "Australia" }
-          , { item = Taiwan, label = "Taiwan"
-          -- other countries
+          [ basicMenuItem
+              { item = Australia, label = "Australia" }
+          , basicMenuitem
+              { item = Taiwan, label = "Taiwan"
+            -- other countries
           ]
 
       yourView =
@@ -762,8 +808,10 @@ devices.
 
       countries : List (MenuItem Country)
       countries =
-          [ { item = Australia, label = "Australia" }
-          , { item = Taiwan, label = "Taiwan"
+          [ basicMenuItem
+              { item = Australia, label = "Australia" }
+          , basicMenuItem
+              { item = Taiwan, label = "Taiwan"
           -- other countries
           ]
 
@@ -853,7 +901,7 @@ update msg (State state_) =
                 Nothing ->
                     ( Nothing, State state_, Cmd.none )
 
-                Just mi ->
+                Just (Basic mi) ->
                     ( Just <| Select mi.item, State state_, Cmd.none )
 
         EnterSelect item ->
@@ -1490,8 +1538,8 @@ viewNative viewNativeData =
                                 ]
                                 [ text ("(" ++ viewNativeData.placeholder ++ ")") ]
 
-                buildList item =
-                    option (StyledAttribs.value item.label :: withSelectedOption item) [ text item.label ]
+                buildList ((Basic item) as menuItem) =
+                    option (StyledAttribs.value item.label :: withSelectedOption menuItem) [ text item.label ]
 
                 (SelectId selectId) =
                     viewNativeData.selectId
@@ -1675,115 +1723,206 @@ viewMenu viewMenuData =
                 )
 
 
-viewMenuItem : ViewMenuItemData item -> ( String, Html (Msg item) )
-viewMenuItem viewMenuItemData =
-    ( String.fromInt viewMenuItemData.index
-    , lazy
-        (\data ->
-            let
-                resolveMouseLeave =
-                    if data.isClickFocused then
-                        [ on "mouseleave" <| Decode.succeed ClearFocusedItem ]
 
-                    else
-                        []
+-- viewMenuItem : ViewMenuItemData item -> ( String, Html (Msg item) )
+-- viewMenuItem viewMenuItemData =
+--     ( String.fromInt viewMenuItemData.index
+--     , lazy
+--         (\data ->
+--             let
+--                 (Basic item) =
+--                     data.menuItem
+--                 resolveMouseLeave =
+--                     if data.isClickFocused then
+--                         [ on "mouseleave" <| Decode.succeed ClearFocusedItem ]
+--                     else
+--                         []
+--                 resolveMouseUpMsg =
+--                     case viewMenuItemData.variant of
+--                         Multi _ _ ->
+--                             SelectedItemMulti item viewMenuItemData.selectId
+--                         _ ->
+--                             SelectedItem item
+--                 resolveMouseUp =
+--                     case data.initialMousedown of
+--                         MenuItemMousedown _ ->
+--                             [ on "mouseup" <| Decode.succeed resolveMouseUpMsg ]
+--                         _ ->
+--                             []
+--                 resolveDataTestId =
+--                     if data.menuItemIsTarget then
+--                         [ attribute "data-test-id" ("listBoxItemTargetFocus" ++ String.fromInt data.index) ]
+--                     else
+--                         []
+--                 withTargetStyles =
+--                     if data.menuItemIsTarget && not data.itemSelected then
+--                         [ Css.color (Styles.getMenuItemColorHoverNotSelected viewMenuItemData.menuItemStyles)
+--                         , Css.backgroundColor (Styles.getMenuItemBackgroundColorNotSelected viewMenuItemData.menuItemStyles)
+--                         ]
+--                     else
+--                         []
+--                 withIsClickedStyles =
+--                     if data.isClickFocused then
+--                         [ Css.backgroundColor (Styles.getMenuItemBackgroundColorClicked viewMenuItemData.menuItemStyles) ]
+--                     else
+--                         []
+--                 withIsSelectedStyles =
+--                     if data.itemSelected then
+--                         [ Css.backgroundColor (Styles.getMenuItemBackgroundColorSelected viewMenuItemData.menuItemStyles)
+--                         , Css.hover [ Css.color (Styles.getMenuItemColorHoverSelected viewMenuItemData.menuItemStyles) ]
+--                         ]
+--                     else
+--                         []
+--                 resolveSelectedAriaAttribs =
+--                     if data.itemSelected then
+--                         [ ariaSelected "true" ]
+--                     else
+--                         [ ariaSelected "false" ]
+--                 resolvePosinsetAriaAttrib =
+--                     [ attribute "aria-posinset" (String.fromInt <| data.index + 1) ]
+--             in
+--             -- option
+--             li
+--                 ([ role "option"
+--                  , tabindex -1
+--                  , preventDefaultOn "mousedown" <| Decode.map (\msg -> ( msg, True )) <| Decode.succeed (MenuItemClickFocus data.index)
+--                  , on "mouseover" <| Decode.succeed (HoverFocused data.index)
+--                  , id (menuItemId data.selectId data.index)
+--                  , StyledAttribs.css
+--                     ([ Css.color Css.inherit
+--                      , Css.cursor Css.default
+--                      , Css.display Css.block
+--                      , Css.fontSize Css.inherit
+--                      , Css.width (Css.pct 100)
+--                      , Css.property "user-select" "none"
+--                      , Css.boxSizing Css.borderBox
+--                      , Css.borderRadius (Css.px (Styles.getMenuItemBorderRadius viewMenuItemData.menuItemStyles))
+--                      , Css.padding2 (Css.px 8) (Css.px 8)
+--                      , Css.outline Css.none
+--                      , Css.color (Styles.getMenuItemColor viewMenuItemData.menuItemStyles)
+--                      ]
+--                         ++ withTargetStyles
+--                         ++ withIsClickedStyles
+--                         ++ withIsSelectedStyles
+--                     )
+--                  ]
+--                     ++ resolveMouseLeave
+--                     ++ resolveMouseUp
+--                     ++ resolveDataTestId
+--                     ++ resolveSelectedAriaAttribs
+--                     ++ resolvePosinsetAriaAttrib
+--                 )
+--                 [ text item.label ]
+--         )
+--         viewMenuItemData
+--     )
 
-                resolveMouseUpMsg =
-                    case viewMenuItemData.variant of
-                        Multi _ _ ->
-                            SelectedItemMulti data.menuItem.item viewMenuItemData.selectId
 
-                        _ ->
-                            SelectedItem data.menuItem.item
+viewBasicMenuItem : ViewBasicMenuItemData item -> ( String, Html (Msg item) )
+viewBasicMenuItem data =
+    ( String.fromInt data.index
+    , let
+        resolveMouseLeave =
+            if data.isClickFocused then
+                [ on "mouseleave" <| Decode.succeed ClearFocusedItem ]
 
-                resolveMouseUp =
-                    case data.initialMousedown of
-                        MenuItemMousedown _ ->
-                            [ on "mouseup" <| Decode.succeed resolveMouseUpMsg ]
+            else
+                []
 
-                        _ ->
-                            []
+        resolveMouseUpMsg =
+            case data.variant of
+                Multi _ _ ->
+                    SelectedItemMulti data.menuItem.item data.selectId
 
-                resolveDataTestId =
-                    if data.menuItemIsTarget then
-                        [ attribute "data-test-id" ("listBoxItemTargetFocus" ++ String.fromInt data.index) ]
+                _ ->
+                    SelectedItem data.menuItem.item
 
-                    else
-                        []
+        resolveMouseUp =
+            case data.initialMousedown of
+                MenuItemMousedown _ ->
+                    [ on "mouseup" <| Decode.succeed resolveMouseUpMsg ]
 
-                withTargetStyles =
-                    if data.menuItemIsTarget && not data.itemSelected then
-                        [ Css.color (Styles.getMenuItemColorHoverNotSelected viewMenuItemData.menuItemStyles)
-                        , Css.backgroundColor (Styles.getMenuItemBackgroundColorNotSelected viewMenuItemData.menuItemStyles)
-                        ]
+                _ ->
+                    []
 
-                    else
-                        []
+        resolveDataTestId =
+            if data.menuItemIsTarget then
+                [ attribute "data-test-id" ("listBoxItemTargetFocus" ++ String.fromInt data.index) ]
 
-                withIsClickedStyles =
-                    if data.isClickFocused then
-                        [ Css.backgroundColor (Styles.getMenuItemBackgroundColorClicked viewMenuItemData.menuItemStyles) ]
+            else
+                []
 
-                    else
-                        []
+        withTargetStyles =
+            if data.menuItemIsTarget && not data.itemSelected then
+                [ Css.color (Styles.getMenuItemColorHoverNotSelected data.menuItemStyles)
+                , Css.backgroundColor (Styles.getMenuItemBackgroundColorNotSelected data.menuItemStyles)
+                ]
 
-                withIsSelectedStyles =
-                    if data.itemSelected then
-                        [ Css.backgroundColor (Styles.getMenuItemBackgroundColorSelected viewMenuItemData.menuItemStyles)
-                        , Css.hover [ Css.color (Styles.getMenuItemColorHoverSelected viewMenuItemData.menuItemStyles) ]
-                        ]
+            else
+                []
 
-                    else
-                        []
+        withIsClickedStyles =
+            if data.isClickFocused then
+                [ Css.backgroundColor (Styles.getMenuItemBackgroundColorClicked data.menuItemStyles) ]
 
-                resolveSelectedAriaAttribs =
-                    if data.itemSelected then
-                        [ ariaSelected "true" ]
+            else
+                []
 
-                    else
-                        [ ariaSelected "false" ]
+        withIsSelectedStyles =
+            if data.itemSelected then
+                [ Css.backgroundColor (Styles.getMenuItemBackgroundColorSelected data.menuItemStyles)
+                , Css.hover [ Css.color (Styles.getMenuItemColorHoverSelected data.menuItemStyles) ]
+                ]
 
-                resolvePosinsetAriaAttrib =
-                    [ attribute "aria-posinset" (String.fromInt <| data.index + 1) ]
-            in
-            -- option
-            li
-                ([ role "option"
-                 , tabindex -1
-                 , preventDefaultOn "mousedown" <| Decode.map (\msg -> ( msg, True )) <| Decode.succeed (MenuItemClickFocus data.index)
-                 , on "mouseover" <| Decode.succeed (HoverFocused data.index)
-                 , id (menuItemId data.selectId data.index)
-                 , StyledAttribs.css
-                    ([ Css.color Css.inherit
-                     , Css.cursor Css.default
-                     , Css.display Css.block
-                     , Css.fontSize Css.inherit
-                     , Css.width (Css.pct 100)
-                     , Css.property "user-select" "none"
-                     , Css.boxSizing Css.borderBox
-                     , Css.borderRadius (Css.px (Styles.getMenuItemBorderRadius viewMenuItemData.menuItemStyles))
-                     , Css.padding2 (Css.px 8) (Css.px 8)
-                     , Css.outline Css.none
-                     , Css.color (Styles.getMenuItemColor viewMenuItemData.menuItemStyles)
-                     ]
-                        ++ withTargetStyles
-                        ++ withIsClickedStyles
-                        ++ withIsSelectedStyles
-                    )
-                 ]
-                    ++ resolveMouseLeave
-                    ++ resolveMouseUp
-                    ++ resolveDataTestId
-                    ++ resolveSelectedAriaAttribs
-                    ++ resolvePosinsetAriaAttrib
-                )
-                [ text data.menuItem.label ]
+            else
+                []
+
+        resolveSelectedAriaAttribs =
+            if data.itemSelected then
+                [ ariaSelected "true" ]
+
+            else
+                [ ariaSelected "false" ]
+
+        resolvePosinsetAriaAttrib =
+            [ attribute "aria-posinset" (String.fromInt <| data.index + 1) ]
+      in
+      -- option
+      li
+        ([ role "option"
+         , tabindex -1
+         , preventDefaultOn "mousedown" <| Decode.map (\msg -> ( msg, True )) <| Decode.succeed (MenuItemClickFocus data.index)
+         , on "mouseover" <| Decode.succeed (HoverFocused data.index)
+         , id (menuItemId data.selectId data.index)
+         , StyledAttribs.css
+            ([ Css.color Css.inherit
+             , Css.cursor Css.default
+             , Css.display Css.block
+             , Css.fontSize Css.inherit
+             , Css.width (Css.pct 100)
+             , Css.property "user-select" "none"
+             , Css.boxSizing Css.borderBox
+             , Css.borderRadius (Css.px (Styles.getMenuItemBorderRadius data.menuItemStyles))
+             , Css.padding2 (Css.px 8) (Css.px 8)
+             , Css.outline Css.none
+             , Css.color (Styles.getMenuItemColor data.menuItemStyles)
+             ]
+                ++ withTargetStyles
+                ++ withIsClickedStyles
+                ++ withIsSelectedStyles
+            )
+         ]
+            ++ resolveMouseLeave
+            ++ resolveMouseUp
+            ++ resolveDataTestId
+            ++ resolveSelectedAriaAttribs
+            ++ resolvePosinsetAriaAttrib
         )
-        viewMenuItemData
+        [ text data.menuItem.label ]
     )
 
 
-viewPlaceholder : Configuration item -> Html (Msg item)
+viewPlaceholder : Configuration item -> Html msg
 viewPlaceholder config =
     let
         controlStyles =
@@ -1797,8 +1936,8 @@ viewPlaceholder config =
         [ text config.placeholder ]
 
 
-viewSelectedPlaceholder : Styles.ControlConfig -> MenuItem item -> Html (Msg item)
-viewSelectedPlaceholder controlStyles item =
+viewSelectedPlaceholder : Styles.ControlConfig -> MenuItem item -> Html msg
+viewSelectedPlaceholder controlStyles (Basic item) =
     let
         addedStyles =
             [ Css.maxWidth (Css.calc (Css.pct 100) Css.minus (Css.px 8))
@@ -1837,7 +1976,7 @@ viewSelectInput viewSelectInputData =
             -- there will always be a target item if the menu is
             -- open and not empty
             case viewSelectInputData.maybeActiveTarget of
-                Just mi ->
+                Just (Basic mi) ->
                     [ Events.isEnter (resolveEnterMsg mi) ]
 
                 Nothing ->
@@ -1929,7 +2068,7 @@ viewDummyInput viewDummyInputData =
             -- there will always be a target item if the menu is
             -- open and not empty
             case viewDummyInputData.maybeTargetItem of
-                Just menuitem ->
+                Just (Basic menuitem) ->
                     [ Events.isEnter (EnterSelect menuitem.item) ]
 
                 Nothing ->
@@ -1997,7 +2136,7 @@ viewDummyInput viewDummyInputData =
 
 
 viewMultiValue : SelectId -> MultiSelectConfiguration -> InitialMousedown -> Int -> MenuItem item -> Html (Msg item)
-viewMultiValue selectId config mousedownedItem index menuItem =
+viewMultiValue selectId config mousedownedItem index (Basic menuItem) =
     let
         isMousedowned =
             case mousedownedItem of
@@ -2169,38 +2308,40 @@ buildMenuItems config state_ =
 
 buildMenuItem : Styles.MenuItemConfig -> SelectId -> Variant item -> InitialMousedown -> Int -> MenuNavigation -> Int -> MenuItem item -> ( String, Html (Msg item) )
 buildMenuItem menuItemStyles selectId variant initialMousedown activeTargetIndex menuNavigation idx item =
-    case variant of
-        Single maybeSelectedItem ->
-            viewMenuItem <|
-                ViewMenuItemData
-                    idx
-                    (isSelected item maybeSelectedItem)
-                    (isMenuItemClickFocused initialMousedown idx)
-                    (isTarget activeTargetIndex idx)
-                    selectId
-                    item
-                    menuNavigation
-                    initialMousedown
-                    variant
-                    menuItemStyles
+    case item of
+        Basic bi ->
+            case variant of
+                Single maybeSelectedItem ->
+                    viewBasicMenuItem <|
+                        ViewBasicMenuItemData
+                            idx
+                            (isSelected item maybeSelectedItem)
+                            (isMenuItemClickFocused initialMousedown idx)
+                            (isTarget activeTargetIndex idx)
+                            selectId
+                            bi
+                            menuNavigation
+                            initialMousedown
+                            variant
+                            menuItemStyles
 
-        _ ->
-            viewMenuItem <|
-                ViewMenuItemData
-                    idx
-                    False
-                    (isMenuItemClickFocused initialMousedown idx)
-                    (isTarget activeTargetIndex idx)
-                    selectId
-                    item
-                    menuNavigation
-                    initialMousedown
-                    variant
-                    menuItemStyles
+                _ ->
+                    viewBasicMenuItem <|
+                        ViewBasicMenuItemData
+                            idx
+                            False
+                            (isMenuItemClickFocused initialMousedown idx)
+                            (isTarget activeTargetIndex idx)
+                            selectId
+                            bi
+                            menuNavigation
+                            initialMousedown
+                            variant
+                            menuItemStyles
 
 
 filterMenuItem : Maybe String -> MenuItem item -> Bool
-filterMenuItem maybeQuery item =
+filterMenuItem maybeQuery (Basic item) =
     case maybeQuery of
         Nothing ->
             True

--- a/src/Select.elm
+++ b/src/Select.elm
@@ -1723,10 +1723,9 @@ viewMenu viewMenuData =
                 )
 
 
-viewBasicMenuItem : ViewBasicMenuItemData item -> ( String, Html (Msg item) )
+viewBasicMenuItem : ViewBasicMenuItemData item -> Html (Msg item)
 viewBasicMenuItem data =
-    ( String.fromInt data.index
-    , let
+    let
         resolveMouseLeave =
             if data.isClickFocused then
                 [ on "mouseleave" <| Decode.succeed ClearFocusedItem ]
@@ -1791,9 +1790,9 @@ viewBasicMenuItem data =
 
         resolvePosinsetAriaAttrib =
             [ attribute "aria-posinset" (String.fromInt <| data.index + 1) ]
-      in
-      -- option
-      li
+    in
+    -- option
+    li
         ([ role "option"
          , tabindex -1
          , preventDefaultOn "mousedown" <| Decode.map (\msg -> ( msg, True )) <| Decode.succeed (MenuItemClickFocus data.index)
@@ -1824,7 +1823,6 @@ viewBasicMenuItem data =
             ++ resolvePosinsetAriaAttrib
         )
         [ text data.menuItem.label ]
-    )
 
 
 viewPlaceholder : Configuration item -> Html msg
@@ -2217,7 +2215,8 @@ buildMenuItem menuItemStyles selectId variant initialMousedown activeTargetIndex
         Basic bi ->
             case variant of
                 Single maybeSelectedItem ->
-                    viewBasicMenuItem <|
+                    ( bi.label
+                    , lazy viewBasicMenuItem <|
                         ViewBasicMenuItemData
                             idx
                             (isSelected item maybeSelectedItem)
@@ -2229,9 +2228,11 @@ buildMenuItem menuItemStyles selectId variant initialMousedown activeTargetIndex
                             initialMousedown
                             variant
                             menuItemStyles
+                    )
 
                 _ ->
-                    viewBasicMenuItem <|
+                    ( bi.label
+                    , lazy viewBasicMenuItem <|
                         ViewBasicMenuItemData
                             idx
                             False
@@ -2243,6 +2244,7 @@ buildMenuItem menuItemStyles selectId variant initialMousedown activeTargetIndex
                             initialMousedown
                             variant
                             menuItemStyles
+                    )
 
 
 filterMenuItem : Maybe String -> MenuItem item -> Bool

--- a/src/Select.elm
+++ b/src/Select.elm
@@ -494,8 +494,8 @@ multiTagColor c (MultiSelectConfig config) =
 
 -}
 basicMenuItem : BasicMenuItem item -> MenuItem item
-basicMenuItem defItem =
-    Basic defItem
+basicMenuItem bscItem =
+    Basic bscItem
 
 
 
@@ -1721,101 +1721,6 @@ viewMenu viewMenuData =
                     )
                     viewMenuData.viewableMenuItems
                 )
-
-
-
--- viewMenuItem : ViewMenuItemData item -> ( String, Html (Msg item) )
--- viewMenuItem viewMenuItemData =
---     ( String.fromInt viewMenuItemData.index
---     , lazy
---         (\data ->
---             let
---                 (Basic item) =
---                     data.menuItem
---                 resolveMouseLeave =
---                     if data.isClickFocused then
---                         [ on "mouseleave" <| Decode.succeed ClearFocusedItem ]
---                     else
---                         []
---                 resolveMouseUpMsg =
---                     case viewMenuItemData.variant of
---                         Multi _ _ ->
---                             SelectedItemMulti item viewMenuItemData.selectId
---                         _ ->
---                             SelectedItem item
---                 resolveMouseUp =
---                     case data.initialMousedown of
---                         MenuItemMousedown _ ->
---                             [ on "mouseup" <| Decode.succeed resolveMouseUpMsg ]
---                         _ ->
---                             []
---                 resolveDataTestId =
---                     if data.menuItemIsTarget then
---                         [ attribute "data-test-id" ("listBoxItemTargetFocus" ++ String.fromInt data.index) ]
---                     else
---                         []
---                 withTargetStyles =
---                     if data.menuItemIsTarget && not data.itemSelected then
---                         [ Css.color (Styles.getMenuItemColorHoverNotSelected viewMenuItemData.menuItemStyles)
---                         , Css.backgroundColor (Styles.getMenuItemBackgroundColorNotSelected viewMenuItemData.menuItemStyles)
---                         ]
---                     else
---                         []
---                 withIsClickedStyles =
---                     if data.isClickFocused then
---                         [ Css.backgroundColor (Styles.getMenuItemBackgroundColorClicked viewMenuItemData.menuItemStyles) ]
---                     else
---                         []
---                 withIsSelectedStyles =
---                     if data.itemSelected then
---                         [ Css.backgroundColor (Styles.getMenuItemBackgroundColorSelected viewMenuItemData.menuItemStyles)
---                         , Css.hover [ Css.color (Styles.getMenuItemColorHoverSelected viewMenuItemData.menuItemStyles) ]
---                         ]
---                     else
---                         []
---                 resolveSelectedAriaAttribs =
---                     if data.itemSelected then
---                         [ ariaSelected "true" ]
---                     else
---                         [ ariaSelected "false" ]
---                 resolvePosinsetAriaAttrib =
---                     [ attribute "aria-posinset" (String.fromInt <| data.index + 1) ]
---             in
---             -- option
---             li
---                 ([ role "option"
---                  , tabindex -1
---                  , preventDefaultOn "mousedown" <| Decode.map (\msg -> ( msg, True )) <| Decode.succeed (MenuItemClickFocus data.index)
---                  , on "mouseover" <| Decode.succeed (HoverFocused data.index)
---                  , id (menuItemId data.selectId data.index)
---                  , StyledAttribs.css
---                     ([ Css.color Css.inherit
---                      , Css.cursor Css.default
---                      , Css.display Css.block
---                      , Css.fontSize Css.inherit
---                      , Css.width (Css.pct 100)
---                      , Css.property "user-select" "none"
---                      , Css.boxSizing Css.borderBox
---                      , Css.borderRadius (Css.px (Styles.getMenuItemBorderRadius viewMenuItemData.menuItemStyles))
---                      , Css.padding2 (Css.px 8) (Css.px 8)
---                      , Css.outline Css.none
---                      , Css.color (Styles.getMenuItemColor viewMenuItemData.menuItemStyles)
---                      ]
---                         ++ withTargetStyles
---                         ++ withIsClickedStyles
---                         ++ withIsSelectedStyles
---                     )
---                  ]
---                     ++ resolveMouseLeave
---                     ++ resolveMouseUp
---                     ++ resolveDataTestId
---                     ++ resolveSelectedAriaAttribs
---                     ++ resolvePosinsetAriaAttrib
---                 )
---                 [ text item.label ]
---         )
---         viewMenuItemData
---     )
 
 
 viewBasicMenuItem : ViewBasicMenuItemData item -> ( String, Html (Msg item) )

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -141,6 +141,7 @@ describe("NativeSingle", () => {
     const page = await browser.newPage();
     await page.goto(`${BASE_URI}/NativeSingle.elm`);
     await page.type("[data-test-id=nativeSingleSelect]", "e");
+    await page.waitForTimeout(100);
 
     const selectedIndex: number = await page.$eval(
       "[data-test-id=nativeSingleSelect]",


### PR DESCRIPTION
related: #59 

# Context
We want to create richer menu item views and it is not scalable to add configuration to the current menu item data structure.

## Proposed solution
Make menu item an opaque type so that we can play with different menu item variants to provide an API that allows for custom views.

e.g.

previous 
```
type alias MenuItem item = 
    {  item : item
    ,  label : String
    }
```

current 
```
type alias BasicMenuItem item = 
    {  item : item
    ,  label : String
    }


type  MenuItem item
    =  Basic (BasicMenuItem item)
    |  -- some other exciting new variant
```

## Work completed
- Menu item type is now an opaque type.
- Updated all examples
- Updated README
- Updated elm @docs 