### PR TITLE
Remove multiple arrow events being created on dummy input

### DIFF
--- a/src/Select.elm
+++ b/src/Select.elm
@@ -2072,8 +2072,6 @@ viewDummyInput viewDummyInputData =
                 (Decode.oneOf
                     ([ Events.isSpace (ToggleMenuAtKey <| SelectId viewDummyInputData.id)
                      , Events.isEscape CloseMenu
-                     , Events.isDownArrow (KeyboardDown (SelectId viewDummyInputData.id) viewDummyInputData.totalViewableMenuItems)
-                     , Events.isUpArrow (KeyboardUp (SelectId viewDummyInputData.id) viewDummyInputData.totalViewableMenuItems)
                      ]
                         ++ whenEnterEvent
                         ++ whenArrowEvents


### PR DESCRIPTION
Because we are calling `whenArrowEvents` we don't need to add the arrow
events directly. It defeats the purpose of conditionally creating the arrow events.