### PR TITLE
Icon centereing

### DIFF
--- a/src/Select.elm
+++ b/src/Select.elm
@@ -2504,7 +2504,7 @@ dropdownIndicator controlStyles disabledInput =
                 ]
     in
     span
-        [ StyledAttribs.css resolveIconButtonStyles ]
+        [ StyledAttribs.css [ Css.displayFlex, Css.batch resolveIconButtonStyles ] ]
         [ DropdownIcon.view ]
 
 

--- a/src/Select.elm
+++ b/src/Select.elm
@@ -1532,6 +1532,8 @@ view (Config config) selectId =
                                 [ StyledAttribs.css
                                     [ Css.color (Styles.getControlLoadingIndicatorColor controlStyles)
                                     , Css.height (Css.px 20)
+                                    , Css.displayFlex
+                                    , Css.alignItems Css.center
                                     ]
                                 ]
                                 [ resolveLoadingSpinner ]

--- a/src/Select/Tag.elm
+++ b/src/Select/Tag.elm
@@ -214,6 +214,7 @@ viewClear config =
                 [ Css.height (Css.px 16)
                 , Css.width (Css.px 16)
                 , Css.zIndex (Css.int 1)
+                , Css.displayFlex
                 ]
             ]
             [ ClearIcon.view ]


### PR DESCRIPTION
# Context
Some projects may set large line heights on the body and this is affecting how icons render. They typically are off center and look very wrong.

## Solution
- Ensure containers wrapping icons are `display: flex;`