### PR TITLE
Single select bug

### DIFF
--- a/examples/Single.elm
+++ b/examples/Single.elm
@@ -56,6 +56,9 @@ update msg model =
                         Just (Select.Select i) ->
                             Just i |> Debug.log "Selected"
 
+                        Just Select.ClearSingleSelectItem ->
+                            Nothing
+
                         _ ->
                             model.selectedItem
             in
@@ -88,5 +91,6 @@ view m =
                     |> Select.menuItems m.items
                     |> Select.placeholder "Placeholder"
                     |> Select.searchable False
+                    |> Select.clearable True
                 )
         ]

--- a/src/Select.elm
+++ b/src/Select.elm
@@ -2195,15 +2195,11 @@ viewWrapper data =
 
                         _ ->
                             case resolveContainerMsg of
-                                -- Preventing default means we only need to close or open the menu
-                                -- without focusing input. Should do for other variants also.
+                                -- We are only preventing default when the input is actually focused
+                                -- to avoid a blur event on the input.
+                                -- Should do for SearchableSelectContainerClicked also.
                                 UnsearchableSelectContainerClicked ->
-                                    case data.state.controlUiFocused of
-                                        Just Internal.ControlInput ->
-                                            True
-
-                                        _ ->
-                                            False
+                                    data.state.controlUiFocused == Just Internal.ControlInput
 
                                 _ ->
                                     False
@@ -2691,11 +2687,19 @@ viewDummyInput data =
 
                 _ ->
                     []
+
+        resolvePosition =
+            case data.variant of
+                SingleMenu _ ->
+                    style "position" "absolute"
+
+                _ ->
+                    style "position" "initial"
     in
     input
         ([ style "label" "dummyinput"
          , style "background" "0"
-         , style "position" "absolute"
+         , resolvePosition
          , style "border" "0"
          , style "font-size" "inherit"
          , style "outline" "0"

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -313,6 +313,27 @@ describe("Form", () => {
   });
 });
 
+describe("Single", () => {
+  it("opens and closes then opens menu", async () => {
+    const page = await browser.newPage();
+    await page.goto(`${BASE_URI}/Single.elm`);
+
+    await page.click("[data-test-id=selectContainer]");
+    await page.waitForSelector("[data-test-id=listBox]");
+    await page.click("[data-test-id=selectContainer]");
+    await page.waitForTimeout(100);
+    const listBoxVisible = await page.isVisible("[data-test-id=listBox]");
+
+    expect(listBoxVisible).toBeFalsy();
+
+    await page.click("[data-test-id=selectContainer]");
+    await page.waitForTimeout(100);
+    const listBoxVisibleAgain = await page.isVisible("[data-test-id=listBox]");
+
+    expect(listBoxVisibleAgain).toBeTruthy();
+  });
+});
+
 describe("SingleSearchable", () => {
   // LIST BOX
   it("list box visible after matching input", async () => {


### PR DESCRIPTION
# Context
- Fixed single unsearchable variant placeholder not rendering correctly. This has to do with the absolute positioning of the dummy input.

![single bug](https://user-images.githubusercontent.com/25443812/189520726-5222cf4b-2279-46dd-b9ca-2d2ac4a26436.png)

- Fixed single unsearchable variant open closing menu.

