### PR TITLE
Menu item groups

### DIFF
--- a/examples/SingleGrouped.elm
+++ b/examples/SingleGrouped.elm
@@ -1,0 +1,139 @@
+module SingleGrouped exposing (..)
+
+import Browser
+import Css
+import Html.Styled as Styled exposing (Html, div, text)
+import Html.Styled.Attributes as StyledAttribs
+import Select exposing (MenuItem, initState, selectIdentifier, update)
+import Select.Styles as Styles
+
+
+type Msg
+    = SelectMsg (Select.Msg String)
+
+
+type alias Model =
+    { selectState : Select.State
+    , items : List (MenuItem String)
+    , selectedItem : Maybe String
+    }
+
+
+customColorGroupStyles : Styles.GroupConfig
+customColorGroupStyles =
+    Styles.getGroupConfig Styles.default
+        |> Styles.setGroupColor (Css.hex "#FF3C33")
+
+
+colorGroup : Select.Group
+colorGroup =
+    Select.group "colours"
+        |> Select.groupStyles customColorGroupStyles
+        |> Select.groupView (text "The colours")
+
+
+flavourGroup : Select.Group
+flavourGroup =
+    Select.group "flavours"
+
+
+init : ( Model, Cmd Msg )
+init =
+    ( { selectState = initState (selectIdentifier "SingleSelectExample")
+      , items =
+            [ Select.groupedMenuItem colorGroup
+                (Select.basicMenuItem { item = "Ocean", label = "Ocean" })
+            , Select.basicMenuItem { item = "Random", label = "Random" }
+            , Select.groupedMenuItem colorGroup
+                (Select.basicMenuItem { item = "Blue", label = "Blue" })
+            , Select.groupedMenuItem colorGroup
+                (Select.basicMenuItem { item = "Purple", label = "Purple" })
+            , Select.groupedMenuItem colorGroup
+                (Select.basicMenuItem { item = "Red", label = "Red" })
+            , Select.groupedMenuItem colorGroup
+                (Select.basicMenuItem { item = "Orange", label = "Orange" })
+            , Select.groupedMenuItem colorGroup
+                (Select.basicMenuItem { item = "Yellow", label = "Yellow" })
+            , Select.groupedMenuItem colorGroup
+                (Select.basicMenuItem { item = "Green", label = "Green" })
+            , Select.groupedMenuItem colorGroup
+                (Select.basicMenuItem { item = "Forest", label = "Forest" })
+            , Select.groupedMenuItem colorGroup
+                (Select.basicMenuItem { item = "Slate", label = "Slate" })
+            , Select.groupedMenuItem colorGroup
+                (Select.basicMenuItem { item = "Silver", label = "Silver" })
+            , Select.groupedMenuItem flavourGroup
+                (Select.basicMenuItem { item = "Vanilla", label = "Vanilla" })
+            , Select.groupedMenuItem flavourGroup
+                (Select.basicMenuItem { item = "Chocolate", label = "Chocolate" })
+            , Select.groupedMenuItem flavourGroup
+                (Select.basicMenuItem { item = "Strawberry", label = "Strawberry" })
+            , Select.basicMenuItem { item = "Salted Caramel", label = "Salted Caramel" }
+            ]
+      , selectedItem = Nothing
+      }
+    , Cmd.none
+    )
+
+
+main : Program () Model Msg
+main =
+    Browser.element
+        { init = always init
+        , view = view >> Styled.toUnstyled
+        , update = update
+        , subscriptions = \_ -> Sub.none
+        }
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        SelectMsg sm ->
+            let
+                ( maybeAction, selectState, cmds ) =
+                    Select.update sm model.selectState
+
+                updatedSelectedItem =
+                    case maybeAction of
+                        Just (Select.Select i) ->
+                            Just i |> Debug.log "Selected"
+
+                        Just Select.ClearSingleSelectItem ->
+                            Nothing
+
+                        _ ->
+                            model.selectedItem
+            in
+            ( { model | selectState = selectState, selectedItem = updatedSelectedItem }, Cmd.map SelectMsg cmds )
+
+
+view : Model -> Html Msg
+view m =
+    let
+        selectedItem =
+            case m.selectedItem of
+                Just i ->
+                    Just (Select.basicMenuItem { item = i, label = i })
+
+                _ ->
+                    Nothing
+    in
+    div
+        [ StyledAttribs.css
+            [ Css.marginTop (Css.px 20)
+            , Css.width (Css.pct 50)
+            , Css.marginLeft Css.auto
+            , Css.marginRight Css.auto
+            ]
+        ]
+        [ Styled.map SelectMsg <|
+            Select.view
+                (Select.single selectedItem
+                    |> Select.state m.selectState
+                    |> Select.menuItems m.items
+                    |> Select.placeholder "Placeholder"
+                    |> Select.searchable False
+                    |> Select.clearable True
+                )
+        ]

--- a/src/Select/Internal.elm
+++ b/src/Select/Internal.elm
@@ -1,6 +1,7 @@
 module Select.Internal exposing
     ( BaseMenuItem
     , Direction(..)
+    , Group
     , InitialMousedown(..)
     , UiFocused(..)
     , calculateNextActiveTarget
@@ -9,7 +10,7 @@ module Select.Internal exposing
     )
 
 import Html.Styled as Styled
-import Select.Styles exposing (MenuItemConfig)
+import Select.Styles exposing (GroupConfig, MenuItemConfig)
 
 
 type Direction
@@ -66,6 +67,14 @@ type alias BaseMenuItem comparable =
     { comparable
         | filterable : Bool
         , styles : Maybe MenuItemConfig
+        , group : Maybe Group
+    }
+
+
+type alias Group =
+    { name : String
+    , styles : Maybe GroupConfig
+    , view : Maybe (Styled.Html Never)
     }
 
 

--- a/src/Select/Styles.elm
+++ b/src/Select/Styles.elm
@@ -1,11 +1,12 @@
 module Select.Styles exposing
-    ( Config, ControlConfig, MenuConfig, MenuControlConfig, MenuItemConfig, default
+    ( Config, ControlConfig, MenuConfig, MenuControlConfig, GroupConfig, MenuItemConfig, default
     , setControlStyles, setControlBackgroundColor, setControlBackgroundColorHover, setControlBorderColor, setControlBorderColorFocus, setControlBorderColorHover, setControlBorderRadius, setControlColor, setControlClearIndicatorColor
     , setControlClearIndicatorColorHover, setControlDisabledOpacity, setControlDropdownIndicatorColor, setControlDropdownIndicatorColorHover
     , setControlLoadingIndicatorColor, setControlMinHeight, setControlMultiTagBackgroundColor, setControlMultiTagBorderRadius, setControlMultiTagDismissibleBackgroundColor
     , setControlMultiTagTruncationWidth, setControlSelectedColor, setControlPlaceholderOpacity, setControlSeparatorColor
     , setMenuStyles, setMenuBackgroundColor, setMenuBorderRadius, setMenuBorderWidth, setMenuBoxShadowBlur, setMenuBoxShadowColor, setMenuBoxShadowHOffset, setMenuBoxShadowVOffset, getMenuControlBackgroundColorHover
     , setMenuControlBackgroundColor, setMenuControlBackgroundColorHover, setMenuControlBorderColor, setMenuMaxHeightPx, setMenuMaxHeightVh, setMenuPosition
+    , setGroupStyles, setGroupColor, setGroupFontSizeLabel, setGroupFontWeightLabel, setGroupTextTransformationLabel
     , setMenuItemStyles, setMenuItemBackgroundColorClicked, setMenuItemBackgroundColorSelected, setMenuItemBlockPadding, setMenuItemBorderRadius, setMenuItemColor, setMenuItemBackgroundColorNotSelected, setMenuItemColorHoverSelected, setMenuItemInlinePadding
     , setMenuItemColorHoverNotSelected, setMenuControlBorderColorFocus, setMenuControlBorderColorHover, setMenuControlBorderRadius, setMenuControlClearIndicatorColor
     , setMenuControlClearIndicatorColorHover, setMenuControlColor, setMenuControlDisabledOpacity, setMenuControlLoadingIndicatorColor, setMenuControlMinHeight, setMenuControlPlaceholderOpacity
@@ -18,6 +19,7 @@ module Select.Styles exposing
     , getMenuControlBorderColor, getMenuControlBorderColorFocus, getMenuControlBorderColorHover, getMenuControlBorderRadius, getMenuControlClearIndicatorColor, getMenuControlClearIndicatorColorHover
     , getMenuControlColor, getMenuControlDisabledOpacity, getMenuControlLoadingIndicatorColor, getMenuControlMinHeight, getMenuControlPlaceholderOpacity
     , getMenuControlSearchIndicatorColor, getMenuMaxHeight, getMenuPosition
+    , getGroupConfig, getGroupColor, getGroupFontSizeLabel, getGroupFontWeightLabel, getGroupTextTransformationLabel
     , getMenuItemConfig, getMenuItemBackgroundColorSelected, getMenuItemBackgroundColorClicked, getMenuItemBlockPadding, getMenuItemBorderRadius, getMenuItemColor, getMenuItemColorHoverSelected, getMenuItemColorHoverNotSelected, getMenuItemInlinePadding
     , getMenuItemBackgroundColorNotSelected
     , dracula
@@ -37,7 +39,7 @@ This means when you are setting styles to the [MenuConfig](#MenuConfig) you can 
 NOTE: The [native](/packages/Confidenceman02/elm-select/latest/Select#singleNative) Select variant
 only respects some of the styles.
 
-@docs Config, ControlConfig, MenuConfig, MenuControlConfig, MenuItemConfig, default
+@docs Config, ControlConfig, MenuConfig, MenuControlConfig, GroupConfig, MenuItemConfig, default
 
 
 # Setters
@@ -57,6 +59,11 @@ Set styles
 
 @docs setMenuStyles, setMenuBackgroundColor, setMenuBorderRadius, setMenuBorderWidth, setMenuBoxShadowBlur, setMenuBoxShadowColor, setMenuBoxShadowHOffset, setMenuBoxShadowVOffset, getMenuControlBackgroundColorHover
 @docs setMenuControlBackgroundColor, setMenuControlBackgroundColorHover, setMenuControlBorderColor, setMenuMaxHeightPx, setMenuMaxHeightVh, setMenuPosition
+
+
+# Group
+
+@docs setGroupStyles, setGroupColor, setGroupFontSizeLabel, setGroupFontWeightLabel, setGroupTextTransformationLabel
 
 
 # Menu item
@@ -86,6 +93,11 @@ Get styles
 @docs getMenuControlBorderColor, getMenuControlBorderColorFocus, getMenuControlBorderColorHover, getMenuControlBorderRadius, getMenuControlClearIndicatorColor, getMenuControlClearIndicatorColorHover
 @docs getMenuControlColor, getMenuControlDisabledOpacity, getMenuControlLoadingIndicatorColor, getMenuControlMinHeight, getMenuControlPlaceholderOpacity
 @docs getMenuControlSearchIndicatorColor, getMenuMaxHeight, getMenuPosition
+
+
+# Group
+
+@docs getGroupConfig, getGroupColor, getGroupFontSizeLabel, getGroupFontWeightLabel, getGroupTextTransformationLabel
 
 
 # Menu item
@@ -120,6 +132,11 @@ type MenuConfig
 
 
 {-| -}
+type GroupConfig
+    = GroupConfig GroupConfiguration
+
+
+{-| -}
 type MenuItemConfig
     = MenuItemConfig MenuItemConfiguration
 
@@ -127,6 +144,14 @@ type MenuItemConfig
 {-| -}
 type MenuControlConfig compatible
     = MenuControlConfig (MenuControlConfiguration compatible)
+
+
+type alias GroupConfiguration =
+    { color : Css.Color
+    , fontSizeLabel : String
+    , fontWeightLabel : String
+    , textTransformationLabel : String
+    }
 
 
 type alias MenuItemConfiguration =
@@ -199,7 +224,17 @@ type alias ControlConfiguration compatible =
 type alias Configuration =
     { controlConfig : ControlConfig
     , menuConfig : MenuConfig
+    , menuItemGroup : GroupConfig
     , menuItemConfig : MenuItemConfig
+    }
+
+
+defaultsGroup : GroupConfiguration
+defaultsGroup =
+    { textTransformationLabel = Css.uppercase.value
+    , fontSizeLabel = (Css.px 14).value
+    , fontWeightLabel = (Css.int 500).value
+    , color = Css.hex "#9e9e9e"
     }
 
 
@@ -275,6 +310,11 @@ defaultsControl =
     }
 
 
+menuItemGroupDefault : GroupConfig
+menuItemGroupDefault =
+    GroupConfig defaultsGroup
+
+
 menuItemDefault : MenuItemConfig
 menuItemDefault =
     MenuItemConfig defaultsMenuItem
@@ -294,6 +334,7 @@ defaults : Configuration
 defaults =
     { controlConfig = controlDefault
     , menuConfig = menuDefault
+    , menuItemGroup = menuItemGroupDefault
     , menuItemConfig = menuItemDefault
     }
 
@@ -307,6 +348,34 @@ have been configured.
 default : Config
 default =
     Config defaults
+
+
+
+-- SETTERS GROUP
+
+
+{-| -}
+setGroupColor : Css.Color -> GroupConfig -> GroupConfig
+setGroupColor clr (GroupConfig config) =
+    GroupConfig { config | color = clr }
+
+
+{-| -}
+setGroupFontSizeLabel : Css.FontSize a -> GroupConfig -> GroupConfig
+setGroupFontSizeLabel fs (GroupConfig config) =
+    GroupConfig { config | fontSizeLabel = fs.value }
+
+
+{-| -}
+setGroupFontWeightLabel : Css.FontWeight a -> GroupConfig -> GroupConfig
+setGroupFontWeightLabel fs (GroupConfig config) =
+    GroupConfig { config | fontWeightLabel = fs.value }
+
+
+{-| -}
+setGroupTextTransformationLabel : Css.TextTransform a -> GroupConfig -> GroupConfig
+setGroupTextTransformationLabel fs (GroupConfig config) =
+    GroupConfig { config | textTransformationLabel = fs.value }
 
 
 
@@ -814,6 +883,25 @@ setMenuStyles menuConfig (Config config) =
     Config { config | menuConfig = menuConfig }
 
 
+{-| Set styles for Select menu item groups
+
+        groupBranding : GroupConfig
+        groupBranding =
+            getGroupConfig default
+                |> setGroupColor (Css.hex "#000000")
+
+
+        selectBranding : Config
+        selectBranding
+                default
+                    |> setGroupStyles groupBranding
+
+-}
+setGroupStyles : GroupConfig -> Config -> Config
+setGroupStyles groupConfig (Config config) =
+    Config { config | menuItemGroup = groupConfig }
+
+
 {-| Set styles for Select menu item
 
         menuItemBranding : MenuItemConfig
@@ -831,6 +919,51 @@ setMenuStyles menuConfig (Config config) =
 setMenuItemStyles : MenuItemConfig -> Config -> Config
 setMenuItemStyles menuItemConfig (Config config) =
     Config { config | menuItemConfig = menuItemConfig }
+
+
+
+-- GETTERS GROUP
+
+
+{-| Get the GroupConfig
+
+    baseStyles : Config
+    baseStyles =
+        default
+
+    baseGroupStyles : GroupConfig
+    baseGroupStyles =
+        getGroupConfig baseStyles
+            |> setGroupColor (Css.hex "#000000")
+
+-}
+getGroupConfig : Config -> GroupConfig
+getGroupConfig (Config config) =
+    config.menuItemGroup
+
+
+{-| -}
+getGroupColor : GroupConfig -> Css.Color
+getGroupColor (GroupConfig config) =
+    config.color
+
+
+{-| -}
+getGroupFontSizeLabel : GroupConfig -> String
+getGroupFontSizeLabel (GroupConfig config) =
+    config.fontSizeLabel
+
+
+{-| -}
+getGroupFontWeightLabel : GroupConfig -> String
+getGroupFontWeightLabel (GroupConfig config) =
+    config.fontWeightLabel
+
+
+{-| -}
+getGroupTextTransformationLabel : GroupConfig -> String
+getGroupTextTransformationLabel (GroupConfig config) =
+    config.textTransformationLabel
 
 
 

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -17,7 +17,7 @@ describe("examples", () => {
     const page = await browser.newPage();
 
     await page.goto(BASE_URI);
-    const singleExampleVisible = await page.isVisible(
+    const singleSearchableVisible = await page.isVisible(
       "text=SingleSearchable.elm"
     );
     const nativeSingle = await page.isVisible("text=NativeSingle.elm");
@@ -27,6 +27,7 @@ describe("examples", () => {
     const multiExampleVisible = await page.isVisible("text=Multi.elm");
     const multiFilterable = await page.isVisible("text=MultiFilterable.elm");
     const singleVisible = await page.isVisible("text=Single.elm");
+    const singleGroupVisible = await page.isVisible("text=SingleGrouped.elm");
     const formVisible = await page.isVisible("text=Form.elm");
     const customMenuItemsVisible = await page.isVisible(
       "text=CustomMenuItems.elm"
@@ -36,16 +37,31 @@ describe("examples", () => {
       "text=SingleMenuOpen.elm"
     );
 
-    expect(singleExampleVisible).toBeTruthy();
+    expect(singleSearchableVisible).toBeTruthy();
     expect(nativeSingle).toBeTruthy();
     expect(multiAsyncExampleVisible).toBeTruthy();
     expect(multiFilterable).toBeTruthy();
     expect(multiExampleVisible).toBeTruthy();
     expect(singleVisible).toBeTruthy();
+    expect(singleGroupVisible).toBeTruthy();
     expect(formVisible).toBeTruthy();
     expect(customMenuItemsVisible).toBeTruthy();
     expect(singleMenuVisible).toBeTruthy();
     expect(singleMenuOpenVisible).toBeTruthy();
+  });
+});
+
+describe("SingleGrouped", () => {
+  it("renders groups", async () => {
+    await browser.newContext();
+    const page = await browser.newPage();
+    await page.goto(`${BASE_URI}/SingleGrouped.elm`);
+    await page.click("[data-test-id=selectContainer]");
+    await page.waitForTimeout(100);
+
+    const groupsVisible = await page.locator("[data-test-id=group]").count();
+
+    expect(groupsVisible).toEqual(2);
   });
 });
 
@@ -322,9 +338,9 @@ describe("Multi", () => {
   it("has input focus after clearing more than 1 multi tag", async () => {
     const page = await browser.newPage();
     await page.goto(`${BASE_URI}/Multi.elm`);
-    const input = page.locator("[data-test-id=selectInput]")
+    const input = page.locator("[data-test-id=selectInput]");
 
-    await input.focus()
+    await input.focus();
     await page.keyboard.press("ArrowDown");
     await page.waitForSelector("[data-test-id=listBox]");
     await page.keyboard.press("Enter");
@@ -335,13 +351,13 @@ describe("Multi", () => {
     await page.waitForSelector("[data-test-id=multi-select-tag-1]");
     await page.locator("[data-test-id=clear]").click();
     await page.waitForTimeout(100);
-    await page.keyboard.press("A")
+    await page.keyboard.press("A");
     const inputValue = await input.evaluate((el: HTMLInputElement) => {
-      return el.value
-    })
+      return el.value;
+    });
 
-    expect(inputValue).toEqual("A")
-  })
+    expect(inputValue).toEqual("A");
+  });
 
   it("renders multi select tag when selecting item", async () => {
     const page = await browser.newPage();


### PR DESCRIPTION
Addresses #123 

## Limitations
### Group ordering
- Currently groups are being sorted in a `Dict` as they appear on menu items. The group name is being used as the key so the order will render in alphabetical order which may not be what a user wants.

- Ungrouped menu items always render before grouped items.

