### PR TITLE
update: reduce wait time still fix flakiness

### DIFF
--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -963,7 +963,7 @@ describe("JsOptimized", () => {
     expect(dynamicAttribsVisibleBeforeFocus).toBeFalsy();
 
     await page.focus("[data-test-id=selectInput]");
-    await page.waitForTimeout(200);
+    await page.waitForTimeout(15);
     const dynamicAttribsVisibleAfterFocus = await page.isVisible(
       `[data-es-dynamic-select-input]`
     );


### PR DESCRIPTION
Hello! 
Our team is investigating the impact of waiting time on flaky testing in asynchronous issues. We use your project and test code as one of our research data cases. Our experiments and test data have demonstrated that if the waiting time in the current test file is adjusted from 100ms to 13ms, it can still guarantee the success of all 100 rerun tests, and can also mitigate the running time of test files to a certain extent.

The new waiting time can alleviate flakiness while saving test execution time compared to the original time values.

We appreciate your consideration and look forward to hearing your thoughts and feedback.