### PR TITLE
Remove box shadow in tailwind styles

### DIFF
--- a/src/Select/SelectInput.elm
+++ b/src/Select/SelectInput.elm
@@ -282,6 +282,7 @@ view (Config config) id_ =
             , style "outline" "0px"
             , style "padding" "0px"
             , style "color" "inherit"
+            , style "box-shadow" "none"
             ]
                 ++ inputWidthStyle
 


### PR DESCRIPTION
Addresses #187 

Tailwind adds a box shadow to input elements which affects the custom variant search input styling.