### PR TITLE
Reduce size of tag padding

### DIFF
--- a/src/Select/Tag.elm
+++ b/src/Select/Tag.elm
@@ -134,7 +134,7 @@ view (Config config) value =
                  , Css.fontSize (Css.pct 90)
                  , Css.fontWeight (Css.int 400)
                  , Css.padding4 (Css.px 5) (Css.px 8) (Css.px 5) (Css.px 8)
-                 , Css.property "padding-block" (Css.px 5).value
+                 , Css.property "padding-block" (Css.px 3).value
                  , Css.property "padding-inline" (Css.px 8).value
                  , Css.boxSizing Css.borderBox
                  ]


### PR DESCRIPTION
The tag padding actually makes the control be taller than the min height. By default the control should be at its base height and only grow during wrapping which happens when many multi select items have been selected.